### PR TITLE
Fixing invalid indexes for events causes us to de-dupe them

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,7 @@ type TokenEvent @entity {
     # Common event details
     timestamp: BigInt!
     transactionHash: Bytes!
+    transactionIndex: BigInt!
     logIndex: BigInt!
     eventAddress: Bytes!
     eventTxFrom: Bytes!
@@ -37,6 +38,7 @@ type TransferEvent @entity {
     # Common event details
     timestamp: BigInt!
     transactionHash: Bytes!
+    transactionIndex: BigInt!
     logIndex: BigInt!
     eventAddress: Bytes!
     eventTxFrom: Bytes!
@@ -58,6 +60,7 @@ type AuctionEvent @entity {
     # Common event details
     timestamp: BigInt!
     transactionHash: Bytes!
+    transactionIndex: BigInt!
     logIndex: BigInt!
     eventAddress: Bytes!
     eventTxFrom: Bytes!
@@ -89,6 +92,7 @@ type ActivityEvent @entity {
     # Common event details
     timestamp: BigInt!
     transactionHash: Bytes!
+    transactionIndex: BigInt!
     logIndex: BigInt!
     eventAddress: Bytes!
     eventTxFrom: Bytes!

--- a/src/services/ActivityEvent.service.ts
+++ b/src/services/ActivityEvent.service.ts
@@ -71,9 +71,13 @@ function createEditionEvent(
         event.buyer = buyer as Address
     }
 
+    // `${transactionHash}-${logIndex}` is unique to each log
     event.timestamp = rawEvent.block.timestamp;
     event.transactionHash = rawEvent.transaction.hash;
-    event.logIndex = rawEvent.transaction.index;
+    // The transactionIndex is the index of the transaction in the block
+    event.transactionIndex = rawEvent.transaction.index;
+    // The logIndex is the index of the log in the block logs
+    event.logIndex = rawEvent.transactionLogIndex;
     event.eventAddress = rawEvent.address;
     if (rawEvent.transaction.to) {
         event.eventTxTo = rawEvent.transaction.to;
@@ -283,9 +287,13 @@ function createTokenEvent(
         event.buyer = buyer as Address
     }
 
+    // `${transactionHash}-${logIndex}` is unique to each log
     event.timestamp = rawEvent.block.timestamp;
     event.transactionHash = rawEvent.transaction.hash;
-    event.logIndex = rawEvent.transaction.index;
+    // The transactionIndex is the index of the transaction in the block
+    event.transactionIndex = rawEvent.transaction.index;
+    // The logIndex is the index of the log in the block logs
+    event.logIndex = rawEvent.transactionLogIndex;
     event.eventAddress = rawEvent.address;
     if (rawEvent.transaction.to) {
         event.eventTxTo = rawEvent.transaction.to;
@@ -413,9 +421,13 @@ function createdGatedEvent(ID: string, type: string, rawEvent: ethereum.Event, s
         event.eventValueInWei = phase.priceInWei
     }
 
+    // `${transactionHash}-${logIndex}` is unique to each log
     event.timestamp = rawEvent.block.timestamp;
     event.transactionHash = rawEvent.transaction.hash;
-    event.logIndex = rawEvent.transaction.index;
+    // The transactionIndex is the index of the transaction in the block
+    event.transactionIndex = rawEvent.transaction.index;
+    // The logIndex is the index of the log in the block logs
+    event.logIndex = rawEvent.transactionLogIndex;
     event.eventAddress = rawEvent.address;
     if (rawEvent.transaction.to) {
         event.eventTxTo = rawEvent.transaction.to;

--- a/src/services/AuctionEvent.factory.ts
+++ b/src/services/AuctionEvent.factory.ts
@@ -120,11 +120,14 @@ export function createBidIncreased(
 function populateEventDetails(event: ethereum.Event, auctionEvent: AuctionEvent): void {
     auctionEvent.timestamp = event.block.timestamp;
     auctionEvent.transactionHash = event.transaction.hash;
-    auctionEvent.logIndex = event.transaction.index;
+    auctionEvent.transactionIndex = event.transaction.index;
+    auctionEvent.logIndex = event.transactionLogIndex;
     auctionEvent.eventAddress = event.address;
     if (event.transaction.to) {
         auctionEvent.eventTxTo = event.transaction.to;
     }
     auctionEvent.eventTxFrom = event.transaction.from;
     auctionEvent.blockNumber = event.block.number;
+
+
 }

--- a/src/services/TokenEvent.factory.ts
+++ b/src/services/TokenEvent.factory.ts
@@ -290,7 +290,8 @@ export function createBidWithdrawnEvent(
 function populateEventDetails(event: ethereum.Event, tokenEvent: TokenEvent): void {
     tokenEvent.timestamp = event.block.timestamp;
     tokenEvent.transactionHash = event.transaction.hash;
-    tokenEvent.logIndex = event.transaction.index;
+    tokenEvent.transactionIndex = event.transaction.index;
+    tokenEvent.logIndex = event.transactionLogIndex;
     tokenEvent.eventAddress = event.address;
     if (event.transaction.to) {
         tokenEvent.eventTxTo = event.transaction.to;

--- a/src/services/TransferEvent.factory.ts
+++ b/src/services/TransferEvent.factory.ts
@@ -26,7 +26,8 @@ export function createTransferEvent(event: ethereum.Event, tokenId: BigInt, from
 function populateEventDetails(event: ethereum.Event, transferEvent: TransferEvent): void {
     transferEvent.timestamp = event.block.timestamp;
     transferEvent.transactionHash = event.transaction.hash;
-    transferEvent.logIndex = event.transaction.index;
+    transferEvent.transactionIndex = event.transaction.index;
+    transferEvent.logIndex = event.transactionLogIndex;
     transferEvent.eventAddress = event.address;
     if (event.transaction.to) {
         transferEvent.eventTxTo = event.transaction.to;

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -7,11 +7,11 @@ dataSources:
   ## KODA V1 (Alpha)
   - kind: ethereum/contract
     name: KnownOriginV1
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0xf0d6a41a3f011e06260f9133101b82b405539167'
+      address: '0xdde2d979e8d39bb8416eafcfc1758f3cab2c9c72'
       abi: KnownOriginV1
-      startBlock: 2054121
+      startBlock: 5381767
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -31,11 +31,11 @@ dataSources:
   ## KODA V2 (Current)
   - kind: ethereum/contract
     name: KnownOriginV2
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x2df6816286c583a7ef8637cd4b7cc1cc62f6161e'
+      address: '0xfbeef911dc5821886e1dda71586d90ed28174b7d'
       abi: KnownOriginV2
-      startBlock: 2932902
+      startBlock: 6270484
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -76,11 +76,11 @@ dataSources:
   ## Auctions V1 (Deprecated)
   - kind: ethereum/contract
     name: ArtistAcceptingBidsV1
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0xC68373E4BCCA5630A82b35b989e9F4Adb1d375c8'
+      address: '0x921ade9018Eec4a01e41e80a7eeBa982B61724Ec'
       abi: ArtistAcceptingBidsV1
-      startBlock: 3211004
+      startBlock: 6568535
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -115,11 +115,11 @@ dataSources:
   ## Auctions V2 (Current)
   - kind: ethereum/contract
     name: ArtistAcceptingBidsV2
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0xb05DA17AA04ac6f57821513572fb7760a203cd98'
+      address: '0x848b0ea643e5a352d78e2c0c12a2dd8c96fec639'
       abi: ArtistAcceptingBidsV2
-      startBlock: 3620647
+      startBlock: 7271800
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -160,11 +160,11 @@ dataSources:
   ## TokenMarketplace V1 (Current)
   - kind: ethereum/contract
     name: TokenMarketplace
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x2AA618cF1Cc8C1223EB0571676E73c7e8117Ed45'
+      address: '0xc1697d340807324200e26e4617Ce9c0070488E23'
       abi: TokenMarketplace
-      startBlock: 6321886
+      startBlock: 9927235
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -205,11 +205,11 @@ dataSources:
   ## TokenMarketplace V2 (Current)
   - kind: ethereum/contract
     name: TokenMarketplaceV2
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0xdAc14EA324560DdC4d0722D8E7636F852697FB69'
+      address: '0xc322cdd03f34b6d25633c2abbc8716a058c7fe9e'
       abi: TokenMarketplaceV2
-      startBlock: 7541509
+      startBlock: 11250377
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -264,11 +264,11 @@ dataSources:
   ## Artist Burner (Current)
   - kind: ethereum/contract
     name: ArtistEditionBurner
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x9dd4cf0a7f1c195cc42c3bfaaa92c70c039058e9'
+      address: '0xcc0b7707ba4d7d7f9acdd16ab2e0b1997e816166'
       abi: ArtistEditionBurner
-      startBlock: 6514505
+      startBlock: 10098533
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -293,11 +293,11 @@ dataSources:
   ## Artist Tools V2
   - kind: ethereum/contract
     name: ArtistEditionControlsV2
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0xC2d4Df7b146a5e5898e66DAa759213882e06dE59'
+      address: '0x5327cf8b4127e81013d706330043e8bf5673f50d'
       abi: ArtistEditionControlsV2
-      startBlock: 3919265
+      startBlock: 7271760
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -316,11 +316,11 @@ dataSources:
   ## KODA V3 (V3 NFT)
   - kind: ethereum/contract
     name: KnownOriginV3
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x3abC8C65A9516D5B487A9F7423aE2C4c6a3Adf51'
+      address: '0xABB3738f04Dc2Ec20f4AE4462c3d069d02AE045B'
       abi: KnownOriginV3
-      startBlock: 9738449
+      startBlock: 13080871
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -391,11 +391,11 @@ dataSources:
   ## KOAccessControls for KODA V3 (V3 NFT)
   - kind: ethereum/contract
     name: KOAccessControls
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x64699bC10a4E4639eD319397200CF16fa0aD1Fc9'
+      address: '0x9028b16494a9363F3EAaf381a6Fde67296abc68C'
       abi: KOAccessControls
-      startBlock: 9738444
+      startBlock: 13080815
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -421,11 +421,11 @@ dataSources:
   ## MintingFactory V1 for KODA V3
   - kind: ethereum/contract
     name: MintingFactoryV1
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x35668a2Fd45452231a2639edcb887cD45951e597'
+      address: '0x36CF31019816E9490959F75Ba9164eDd304De01D'
       abi: MintingFactory
-      startBlock: 9738480
+      startBlock: 13081038
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -459,11 +459,11 @@ dataSources:
   ## MintingFactory V2 for KODA V3
   - kind: ethereum/contract
     name: MintingFactoryV2
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x2346b3949F8742f4e2a8B6F26D72ef358683820d'
+      address: '0xcEcF098DC0F513C68a0003b540CBDAE130dD0014'
       abi: MintingFactory
-      startBlock: 10377122
+      startBlock: 14583177
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -499,11 +499,11 @@ dataSources:
   # Token Primary Marketplace V3 (V3 NFT)
   - kind: ethereum/contract
     name: KODAV3PrimaryMarketplace
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x4B7A8Ce7d004C5c68207F355F6A838C941FF6B96'
+      address: '0xf11ED77fD65840b64602526DDC38311E9923c81B'
       abi: KODAV3PrimaryMarketplace
-      startBlock: 9738462
+      startBlock: 13080907
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -587,11 +587,11 @@ dataSources:
   # Token Secondary Marketplace V3 (V3 NFT)
   - kind: ethereum/contract
     name: KODAV3SecondaryMarketplace
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x1f31f522b51cd5cB847c7228fE3bF9916800aaDe'
+      address: '0x0Eb65B4c3d3dE340e1b15384f8F211784247a37A'
       abi: KODAV3SecondaryMarketplace
-      startBlock: 9738467
+      startBlock: 13080962
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -674,11 +674,11 @@ dataSources:
   # Collab registry
   - kind: ethereum/contract
     name: KODAV3CollabRegistry
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x3005BB70CF6099e919Fb2E846abC8Fa1C710f613'
+      address: '0xe28e054d596576841682e8c993E415B3ccB2EBeB'
       abi: KODAV3CollabRegistry
-      startBlock: 9738473
+      startBlock: 13080981
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -712,11 +712,11 @@ dataSources:
   # koda-v3-gated-marketplace registry
   - kind: ethereum/contract
     name: KODAV3UpgradableGatedMarketplace
-    network: rinkeby
+    network: mainnet
     source:
-      address: '0x048b36a7cc30127cE2C2C8E1C6AF9c3d0D8787eC'
+      address: '0x8fC72C856EB661F072F0f7322449f3fcCF088f42'
       abi: KODAV3UpgradableGatedMarketplace
-      startBlock: 10377112
+      startBlock: 14583128
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -7,11 +7,11 @@ dataSources:
   ## KODA V1 (Alpha)
   - kind: ethereum/contract
     name: KnownOriginV1
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xdde2d979e8d39bb8416eafcfc1758f3cab2c9c72'
+      address: '0xf0d6a41a3f011e06260f9133101b82b405539167'
       abi: KnownOriginV1
-      startBlock: 5381767
+      startBlock: 2054121
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -31,11 +31,11 @@ dataSources:
   ## KODA V2 (Current)
   - kind: ethereum/contract
     name: KnownOriginV2
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xfbeef911dc5821886e1dda71586d90ed28174b7d'
+      address: '0x2df6816286c583a7ef8637cd4b7cc1cc62f6161e'
       abi: KnownOriginV2
-      startBlock: 6270484
+      startBlock: 2932902
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -76,11 +76,11 @@ dataSources:
   ## Auctions V1 (Deprecated)
   - kind: ethereum/contract
     name: ArtistAcceptingBidsV1
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x921ade9018Eec4a01e41e80a7eeBa982B61724Ec'
+      address: '0xC68373E4BCCA5630A82b35b989e9F4Adb1d375c8'
       abi: ArtistAcceptingBidsV1
-      startBlock: 6568535
+      startBlock: 3211004
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -115,11 +115,11 @@ dataSources:
   ## Auctions V2 (Current)
   - kind: ethereum/contract
     name: ArtistAcceptingBidsV2
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x848b0ea643e5a352d78e2c0c12a2dd8c96fec639'
+      address: '0xb05DA17AA04ac6f57821513572fb7760a203cd98'
       abi: ArtistAcceptingBidsV2
-      startBlock: 7271800
+      startBlock: 3620647
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -160,11 +160,11 @@ dataSources:
   ## TokenMarketplace V1 (Current)
   - kind: ethereum/contract
     name: TokenMarketplace
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xc1697d340807324200e26e4617Ce9c0070488E23'
+      address: '0x2AA618cF1Cc8C1223EB0571676E73c7e8117Ed45'
       abi: TokenMarketplace
-      startBlock: 9927235
+      startBlock: 6321886
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -205,11 +205,11 @@ dataSources:
   ## TokenMarketplace V2 (Current)
   - kind: ethereum/contract
     name: TokenMarketplaceV2
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xc322cdd03f34b6d25633c2abbc8716a058c7fe9e'
+      address: '0xdAc14EA324560DdC4d0722D8E7636F852697FB69'
       abi: TokenMarketplaceV2
-      startBlock: 11250377
+      startBlock: 7541509
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -264,11 +264,11 @@ dataSources:
   ## Artist Burner (Current)
   - kind: ethereum/contract
     name: ArtistEditionBurner
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xcc0b7707ba4d7d7f9acdd16ab2e0b1997e816166'
+      address: '0x9dd4cf0a7f1c195cc42c3bfaaa92c70c039058e9'
       abi: ArtistEditionBurner
-      startBlock: 10098533
+      startBlock: 6514505
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -293,11 +293,11 @@ dataSources:
   ## Artist Tools V2
   - kind: ethereum/contract
     name: ArtistEditionControlsV2
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x5327cf8b4127e81013d706330043e8bf5673f50d'
+      address: '0xC2d4Df7b146a5e5898e66DAa759213882e06dE59'
       abi: ArtistEditionControlsV2
-      startBlock: 7271760
+      startBlock: 3919265
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -316,11 +316,11 @@ dataSources:
   ## KODA V3 (V3 NFT)
   - kind: ethereum/contract
     name: KnownOriginV3
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xABB3738f04Dc2Ec20f4AE4462c3d069d02AE045B'
+      address: '0x3abC8C65A9516D5B487A9F7423aE2C4c6a3Adf51'
       abi: KnownOriginV3
-      startBlock: 13080871
+      startBlock: 9738449
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -391,11 +391,11 @@ dataSources:
   ## KOAccessControls for KODA V3 (V3 NFT)
   - kind: ethereum/contract
     name: KOAccessControls
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x9028b16494a9363F3EAaf381a6Fde67296abc68C'
+      address: '0x64699bC10a4E4639eD319397200CF16fa0aD1Fc9'
       abi: KOAccessControls
-      startBlock: 13080815
+      startBlock: 9738444
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -421,11 +421,11 @@ dataSources:
   ## MintingFactory V1 for KODA V3
   - kind: ethereum/contract
     name: MintingFactoryV1
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x36CF31019816E9490959F75Ba9164eDd304De01D'
+      address: '0x35668a2Fd45452231a2639edcb887cD45951e597'
       abi: MintingFactory
-      startBlock: 13081038
+      startBlock: 9738480
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -459,11 +459,11 @@ dataSources:
   ## MintingFactory V2 for KODA V3
   - kind: ethereum/contract
     name: MintingFactoryV2
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xcEcF098DC0F513C68a0003b540CBDAE130dD0014'
+      address: '0x2346b3949F8742f4e2a8B6F26D72ef358683820d'
       abi: MintingFactory
-      startBlock: 14583177
+      startBlock: 10377122
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -499,11 +499,11 @@ dataSources:
   # Token Primary Marketplace V3 (V3 NFT)
   - kind: ethereum/contract
     name: KODAV3PrimaryMarketplace
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xf11ED77fD65840b64602526DDC38311E9923c81B'
+      address: '0x4B7A8Ce7d004C5c68207F355F6A838C941FF6B96'
       abi: KODAV3PrimaryMarketplace
-      startBlock: 13080907
+      startBlock: 9738462
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -587,11 +587,11 @@ dataSources:
   # Token Secondary Marketplace V3 (V3 NFT)
   - kind: ethereum/contract
     name: KODAV3SecondaryMarketplace
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x0Eb65B4c3d3dE340e1b15384f8F211784247a37A'
+      address: '0x1f31f522b51cd5cB847c7228fE3bF9916800aaDe'
       abi: KODAV3SecondaryMarketplace
-      startBlock: 13080962
+      startBlock: 9738467
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -674,11 +674,11 @@ dataSources:
   # Collab registry
   - kind: ethereum/contract
     name: KODAV3CollabRegistry
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xe28e054d596576841682e8c993E415B3ccB2EBeB'
+      address: '0x3005BB70CF6099e919Fb2E846abC8Fa1C710f613'
       abi: KODAV3CollabRegistry
-      startBlock: 13080981
+      startBlock: 9738473
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -712,11 +712,11 @@ dataSources:
   # koda-v3-gated-marketplace registry
   - kind: ethereum/contract
     name: KODAV3UpgradableGatedMarketplace
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x8fC72C856EB661F072F0f7322449f3fcCF088f42'
+      address: '0x048b36a7cc30127cE2C2C8E1C6AF9c3d0D8787eC'
       abi: KODAV3UpgradableGatedMarketplace
-      startBlock: 14583128
+      startBlock: 10377112
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4


### PR DESCRIPTION
We have been using transaction index which is not unique per event within a block, we should have been using log index which is the order of all logs within a block.

The `transactionIndex` is the index of the transaction in the block. The `logIndex` is the index of the log in the block logs

This allows us to then order them properly `blocknumber / log index` with not remove dedupes 

We can then fix this bug https://github.com/knownorigin/known-origin-discovery/issues/966