### PR TITLE
Cc ownership transfers

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -575,6 +575,10 @@ type CreatorContract @entity {
     # banned - flagged by the creator contract factory
     isHidden: Boolean!
 
+    #Transfer details
+    transferState: BigInt!
+    hasBeenTransferred: Boolean!
+
     # Global stats
     totalNumOfEditions: BigInt!
     totalNumOfTokensSold: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -576,6 +576,10 @@ type CreatorContract @entity {
     isHidden: Boolean!
 
     #Transfer details
+    # 0: not transferred
+    # 1: transferred to dead address with no artworks minted
+    # 2: transferred to dead address with artworks minted
+    # 3: transferred to another active address
     transferState: BigInt!
     hasBeenTransferred: Boolean!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -575,13 +575,8 @@ type CreatorContract @entity {
     # banned - flagged by the creator contract factory
     isHidden: Boolean!
 
-    #Transfer details
-    # 0: not transferred
-    # 1: transferred to dead address with no artworks minted
-    # 2: transferred to dead address with artworks minted
-    # 3: transferred to another active address
+    #Transfer details - see transferStates.ts
     transferState: BigInt!
-    hasBeenTransferred: Boolean!
 
     # Global stats
     totalNumOfEditions: BigInt!

--- a/src/mappings/v4-creator-contracts/creator-contract.ts
+++ b/src/mappings/v4-creator-contracts/creator-contract.ts
@@ -68,7 +68,7 @@ import {DEAD_ADDRESS, isWETHAddress, ONE, ONE_ETH, ZERO, ZERO_ADDRESS, ZERO_BIG_
 import {createV4Id} from "./KODAV4"
 import * as tokenService from "../../services/Token.service";
 import { KODA_V4 } from "../../utils/KodaVersions";
-import { RENOUNCED_WITHOUT_ARTWORKS, RENOUNCED_WITH_ARTWORKS, TRANSFERRED_TO_ACTIVE_ADDRESS } from "../../utils/transferStates";
+import { NOT_TRANSFERRED, RENOUNCED_WITHOUT_ARTWORKS, RENOUNCED_WITH_ARTWORKS, TRANSFERRED_TO_ACTIVE_ADDRESS } from "../../utils/transferStates";
 
 export function handleEditionSalesDisabledUpdated(event: EditionSalesDisabledUpdated): void {
     let creatorContractInstance = ERC721CreatorContract.bind(event.address)
@@ -542,15 +542,19 @@ export function handleBuyNowPurchased(event: BuyNowPurchased): void {
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {
     let creatorContractEntity = CreatorContract.load(event.address.toHexString()) as CreatorContract
     creatorContractEntity.owner = event.params.newOwner
-    if (event.params.newOwner.equals(DEAD_ADDRESS) || event.params.newOwner.equals(ZERO_ADDRESS)) {
-        if (creatorContractEntity.totalNumOfEditions > ZERO) {
-            creatorContractEntity.transferState = RENOUNCED_WITH_ARTWORKS;
+
+        if (event.params.newOwner.equals(DEAD_ADDRESS) || event.params.newOwner.equals(ZERO_ADDRESS)) {
+            if (creatorContractEntity.totalNumOfEditions > ZERO) {
+                creatorContractEntity.transferState = RENOUNCED_WITH_ARTWORKS;
+            } else {
+                creatorContractEntity.transferState = RENOUNCED_WITHOUT_ARTWORKS;
+            }
+        } else if (event.params.newOwner.equals(creatorContractEntity.creator)) {
+            creatorContractEntity.transferState = NOT_TRANSFERRED
         } else {
-            creatorContractEntity.transferState = RENOUNCED_WITHOUT_ARTWORKS;
+            creatorContractEntity.transferState = TRANSFERRED_TO_ACTIVE_ADDRESS;
         }
-    } else {
-        creatorContractEntity.transferState = TRANSFERRED_TO_ACTIVE_ADDRESS;
-    }
+
     creatorContractEntity.save()
 
     activityEventService.recordCCOwnershipTransferred(

--- a/src/mappings/v4-creator-contracts/creator-contract.ts
+++ b/src/mappings/v4-creator-contracts/creator-contract.ts
@@ -68,6 +68,7 @@ import {DEAD_ADDRESS, isWETHAddress, ONE, ONE_ETH, ZERO, ZERO_ADDRESS, ZERO_BIG_
 import {createV4Id} from "./KODAV4"
 import * as tokenService from "../../services/Token.service";
 import { KODA_V4 } from "../../utils/KodaVersions";
+import { RENOUNCED_WITHOUT_ARTWORKS, RENOUNCED_WITH_ARTWORKS, TRANSFERRED_TO_ACTIVE_ADDRESS } from "../../utils/transferStates";
 
 export function handleEditionSalesDisabledUpdated(event: EditionSalesDisabledUpdated): void {
     let creatorContractInstance = ERC721CreatorContract.bind(event.address)
@@ -544,12 +545,12 @@ export function handleOwnershipTransferred(event: OwnershipTransferred): void {
     creatorContractEntity.hasBeenTransferred = true;
     if (event.params.newOwner.equals(DEAD_ADDRESS) || event.params.newOwner.equals(ZERO_ADDRESS)) {
         if (creatorContractEntity.totalNumOfEditions > ZERO) {
-            creatorContractEntity.transferState = BigInt.fromI32(2);
+            creatorContractEntity.transferState = RENOUNCED_WITH_ARTWORKS;
         } else {
-            creatorContractEntity.transferState = BigInt.fromI32(1);
+            creatorContractEntity.transferState = RENOUNCED_WITHOUT_ARTWORKS;
         }
     } else {
-        creatorContractEntity.transferState = BigInt.fromI32(3);
+        creatorContractEntity.transferState = TRANSFERRED_TO_ACTIVE_ADDRESS;
     }
     creatorContractEntity.save()
 

--- a/src/mappings/v4-creator-contracts/creator-contract.ts
+++ b/src/mappings/v4-creator-contracts/creator-contract.ts
@@ -541,6 +541,16 @@ export function handleBuyNowPurchased(event: BuyNowPurchased): void {
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {
     let creatorContractEntity = CreatorContract.load(event.address.toHexString()) as CreatorContract
     creatorContractEntity.owner = event.params.newOwner
+    creatorContractEntity.hasBeenTransferred = true;
+    if (event.params.newOwner.equals(DEAD_ADDRESS) || event.params.newOwner.equals(ZERO_ADDRESS)) {
+        if (creatorContractEntity.totalNumOfEditions > ZERO) {
+            creatorContractEntity.transferState = BigInt.fromI32(2);
+        } else {
+            creatorContractEntity.transferState = BigInt.fromI32(1);
+        }
+    } else {
+        creatorContractEntity.transferState = BigInt.fromI32(3);
+    }
     creatorContractEntity.save()
 
     activityEventService.recordCCOwnershipTransferred(

--- a/src/mappings/v4-creator-contracts/creator-contract.ts
+++ b/src/mappings/v4-creator-contracts/creator-contract.ts
@@ -542,7 +542,6 @@ export function handleBuyNowPurchased(event: BuyNowPurchased): void {
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {
     let creatorContractEntity = CreatorContract.load(event.address.toHexString()) as CreatorContract
     creatorContractEntity.owner = event.params.newOwner
-    creatorContractEntity.hasBeenTransferred = true;
     if (event.params.newOwner.equals(DEAD_ADDRESS) || event.params.newOwner.equals(ZERO_ADDRESS)) {
         if (creatorContractEntity.totalNumOfEditions > ZERO) {
             creatorContractEntity.transferState = RENOUNCED_WITH_ARTWORKS;

--- a/src/mappings/v4-creator-contracts/factory.ts
+++ b/src/mappings/v4-creator-contracts/factory.ts
@@ -176,6 +176,7 @@ export function handleCreatorContractBanned(event: CreatorContractBanned): void 
         creatorContractEntity.secondaryRoyaltyPercentage = ZERO;
         creatorContractEntity.defaultFundsRecipients = new Array<Bytes>();
         creatorContractEntity.defaultFundsShares = new Array<BigInt>();
+        creatorContractEntity.transferState = NOT_TRANSFERRED;
         creatorContractEntity.save()
     }
     creatorContractEntity.isHidden = event.params._banned

--- a/src/mappings/v4-creator-contracts/factory.ts
+++ b/src/mappings/v4-creator-contracts/factory.ts
@@ -90,6 +90,9 @@ export function handleSelfSovereignERC721Deployed(event: SelfSovereignERC721Depl
     creatorContractEntity.name = sovereignContractInstance.name()
     creatorContractEntity.symbol = sovereignContractInstance.symbol()
 
+    creatorContractEntity.transferState = ZERO;
+    creatorContractEntity.hasBeenTransferred = false;
+
     const filterRegistry = sovereignContractInstance.try_operatorFilterRegistry()
     if (filterRegistry.reverted === false) {
         creatorContractEntity.filterRegistry = filterRegistry.value

--- a/src/mappings/v4-creator-contracts/factory.ts
+++ b/src/mappings/v4-creator-contracts/factory.ts
@@ -31,6 +31,7 @@ import {Bytes, BigInt} from "@graphprotocol/graph-ts/index";
 import {ZERO, ONE, ZERO_BIG_DECIMAL, DEAD_ADDRESS, ZERO_ADDRESS} from "../../utils/constants";
 import {loadOrCreateArtist} from "../../services/Artist.service";
 import {recordCCBanned, recordCCDeployed, recordV4EditionDisabledUpdated} from "../../services/ActivityEvent.service";
+import { NOT_TRANSFERRED } from "../../utils/transferStates";
 
 // Index the deployment of the factory in order to capture the global V4 params
 export function handleContractDeployed(event: ContractDeployed): void {
@@ -90,8 +91,7 @@ export function handleSelfSovereignERC721Deployed(event: SelfSovereignERC721Depl
     creatorContractEntity.name = sovereignContractInstance.name()
     creatorContractEntity.symbol = sovereignContractInstance.symbol()
 
-    creatorContractEntity.transferState = ZERO;
-    creatorContractEntity.hasBeenTransferred = false;
+    creatorContractEntity.transferState = NOT_TRANSFERRED;
 
     const filterRegistry = sovereignContractInstance.try_operatorFilterRegistry()
     if (filterRegistry.reverted === false) {

--- a/src/utils/transferStates.ts
+++ b/src/utils/transferStates.ts
@@ -1,0 +1,11 @@
+import {BigInt} from "@graphprotocol/graph-ts";
+
+// 0: not transferred
+// 1: transferred to dead address with no artworks minted
+// 2: transferred to dead address with artworks minted
+// 3: transferred to another active address
+
+export let NOT_TRANSFERRED = BigInt.fromI32(0);
+export let RENOUNCED_WITHOUT_ARTWORKS = BigInt.fromI32(1);
+export let RENOUNCED_WITH_ARTWORKS = BigInt.fromI32(2);
+export let TRANSFERRED_TO_ACTIVE_ADDRESS = BigInt.fromI32(3);

--- a/tests/mappings/mockingFunctions.ts
+++ b/tests/mappings/mockingFunctions.ts
@@ -3,7 +3,8 @@ import {
     BuyNowPurchased,
     ListedEditionForBuyNow,
     EditionSalesDisabledUpdated,
-    Transfer
+    Transfer,
+    OwnershipTransferred
 } from "../../generated/KnownOriginV4Factory/ERC721KODACreatorWithBuyItNow";
 import {newMockEvent} from "matchstick-as";
 import {
@@ -73,6 +74,16 @@ export function createEditionSalesDisabledUpdated(editionId: BigInt, disabled: b
 
     event.parameters.push(new ethereum.EventParam("editionId", ethereum.Value.fromUnsignedBigInt(editionId)));
     event.parameters.push(new ethereum.EventParam("disabled", ethereum.Value.fromBoolean(disabled)));
+
+    return event
+}
+
+export function createOwnershipTransferEvent(previousOwner: string, newOwner: string): OwnershipTransferred {
+    let event = changetype<OwnershipTransferred>(newMockEvent());
+    event.parameters = new Array();
+
+    event.parameters.push(new ethereum.EventParam("previousOwner", ethereum.Value.fromAddress(Address.fromString(previousOwner))));
+    event.parameters.push(new ethereum.EventParam("newOwner", ethereum.Value.fromAddress(Address.fromString(newOwner))));
 
     return event
 }

--- a/tests/mappings/v4/known-origin-v4-mapping-creator-contract.test.ts
+++ b/tests/mappings/v4/known-origin-v4-mapping-creator-contract.test.ts
@@ -4,7 +4,8 @@ import {
   handleBuyNowPurchased,
   handleListedForBuyItNow,
   handleTransfer,
-  handleEditionSalesDisabledUpdated
+  handleEditionSalesDisabledUpdated,
+  handleOwnershipTransferred
 } from "../../../src/mappings/v4-creator-contracts/creator-contract";
 import { handleSelfSovereignERC721Deployed } from "../../../src/mappings/v4-creator-contracts/factory";
 import { assert, createMockedFunction, mockIpfsFile } from "matchstick-as";
@@ -18,14 +19,15 @@ import {
   TRANSFER_ENTITY_TYPE
 } from "../entities";
 import * as SaleTypes from "../../../src/utils/SaleTypes";
-import { ZERO, ZERO_ADDRESS } from "../../../src/utils/constants";
-import { CreatorContractSetting } from "../../../generated/schema";
+import { DEAD_ADDRESS, ZERO, ZERO_ADDRESS } from "../../../src/utils/constants";
+import { CreatorContractSetting, CreatorContract } from "../../../generated/schema";
 import {
   createBuyNowPurchasedEvent,
   createListedEditionForBuyNowEvent,
   createSelfSovereignERC721DeployedEvent,
   createTransferEvent,
-  createEditionSalesDisabledUpdated
+  createEditionSalesDisabledUpdated,
+  createOwnershipTransferEvent
 } from "../mockingFunctions";
 import { createV4Id } from "../../../src/mappings/v4-creator-contracts/KODAV4";
 import { createCreatorContractEventId } from "../../../src/services/ActivityEvent.service";
@@ -847,4 +849,78 @@ describe("KODA V4 Creator Contract tests", () => {
 
     })
   });
+
+  describe('Contract transfer tests', () => {
+    test('Can successfully transfer a contract with no NFTs minted', () => {
+      ///////////////////////////
+      // Setup Contract Object //
+      ///////////////////////////
+      const deployer = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+      const artist = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+      const selfSovereignNFT = "0x9f01f6cb996a4ca47841dd9392335296933c7a9f";
+      const implementation = "0x34775b52d205d83f9ed3dfa115be51f84e24c3f7";
+      const fundsHandler = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+
+      const KODAV4_FACTORY = Address.fromString("0x9f01f6cb996a4ca47841dd9392335296933c7a9f");
+      const ssEvent = createSelfSovereignERC721DeployedEvent(deployer, artist, selfSovereignNFT, implementation, fundsHandler);
+      ssEvent.address = KODAV4_FACTORY;
+
+      handleSelfSovereignERC721Deployed(ssEvent);
+
+      const ownershipTransferEvent = createOwnershipTransferEvent(deployer, deployer)
+      ownershipTransferEvent.address = Address.fromString(selfSovereignNFT);
+      handleOwnershipTransferred(ownershipTransferEvent)
+
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '3');
+
+      const renounceOwnershipTransferEvent = createOwnershipTransferEvent(deployer, ZERO_ADDRESS.toHexString())
+      renounceOwnershipTransferEvent.address = Address.fromString(selfSovereignNFT);
+      handleOwnershipTransferred(renounceOwnershipTransferEvent)
+
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '1');
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "owner", ZERO_ADDRESS.toHexString());
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "deployer", deployer);
+
+    })
+
+    test('Can successfully transfer a contract with NFTs minted', () => {
+      ///////////////////////////
+      // Setup Contract Object //
+      ///////////////////////////
+      const deployer = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+      const artist = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+      const selfSovereignNFT = "0x9f01f6cb996a4ca47841dd9392335296933c7a9f";
+      const implementation = "0x34775b52d205d83f9ed3dfa115be51f84e24c3f7";
+      const fundsHandler = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+
+      const KODAV4_FACTORY = Address.fromString("0x9f01f6cb996a4ca47841dd9392335296933c7a9f");
+      const ssEvent = createSelfSovereignERC721DeployedEvent(deployer, artist, selfSovereignNFT, implementation, fundsHandler);
+      ssEvent.address = KODAV4_FACTORY;
+
+      handleSelfSovereignERC721Deployed(ssEvent);
+
+      const ownershipTransferEvent = createOwnershipTransferEvent(deployer, deployer)
+      ownershipTransferEvent.address = Address.fromString(selfSovereignNFT);
+      handleOwnershipTransferred(ownershipTransferEvent)
+
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '3');
+
+      let contractEntity = CreatorContract.load(selfSovereignNFT) as CreatorContract;
+      contractEntity.totalNumOfEditions = BigInt.fromI32(1);
+      contractEntity.save()
+
+      const renounceOwnershipTransferEvent = createOwnershipTransferEvent(deployer, DEAD_ADDRESS.toHexString())
+      renounceOwnershipTransferEvent.address = Address.fromString(selfSovereignNFT);
+      handleOwnershipTransferred(renounceOwnershipTransferEvent)
+
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '2');
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "owner", DEAD_ADDRESS.toHexString());
+      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "deployer", deployer);
+
+    })
+  })
 });

--- a/tests/mappings/v4/known-origin-v4-mapping-creator-contract.test.ts
+++ b/tests/mappings/v4/known-origin-v4-mapping-creator-contract.test.ts
@@ -857,6 +857,7 @@ describe("KODA V4 Creator Contract tests", () => {
       ///////////////////////////
       const deployer = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
       const artist = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+      const receiver = "0x7B953D086BA10043Be46D351B3f4114152f7B896"
       const selfSovereignNFT = "0x9f01f6cb996a4ca47841dd9392335296933c7a9f";
       const implementation = "0x34775b52d205d83f9ed3dfa115be51f84e24c3f7";
       const fundsHandler = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
@@ -867,7 +868,7 @@ describe("KODA V4 Creator Contract tests", () => {
 
       handleSelfSovereignERC721Deployed(ssEvent);
 
-      const ownershipTransferEvent = createOwnershipTransferEvent(deployer, deployer)
+      const ownershipTransferEvent = createOwnershipTransferEvent(deployer, receiver)
       ownershipTransferEvent.address = Address.fromString(selfSovereignNFT);
       handleOwnershipTransferred(ownershipTransferEvent)
 
@@ -889,6 +890,7 @@ describe("KODA V4 Creator Contract tests", () => {
       ///////////////////////////
       const deployer = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
       const artist = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
+      const receiver = "0x7B953D086BA10043Be46D351B3f4114152f7B896"
       const selfSovereignNFT = "0x9f01f6cb996a4ca47841dd9392335296933c7a9f";
       const implementation = "0x34775b52d205d83f9ed3dfa115be51f84e24c3f7";
       const fundsHandler = "0xcda7fc32898873e1f5a12d23d4532efbcb078901";
@@ -899,7 +901,7 @@ describe("KODA V4 Creator Contract tests", () => {
 
       handleSelfSovereignERC721Deployed(ssEvent);
 
-      const ownershipTransferEvent = createOwnershipTransferEvent(deployer, deployer)
+      const ownershipTransferEvent = createOwnershipTransferEvent(deployer, receiver)
       ownershipTransferEvent.address = Address.fromString(selfSovereignNFT);
       handleOwnershipTransferred(ownershipTransferEvent)
 

--- a/tests/mappings/v4/known-origin-v4-mapping-creator-contract.test.ts
+++ b/tests/mappings/v4/known-origin-v4-mapping-creator-contract.test.ts
@@ -871,14 +871,12 @@ describe("KODA V4 Creator Contract tests", () => {
       ownershipTransferEvent.address = Address.fromString(selfSovereignNFT);
       handleOwnershipTransferred(ownershipTransferEvent)
 
-      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '3');
 
       const renounceOwnershipTransferEvent = createOwnershipTransferEvent(deployer, ZERO_ADDRESS.toHexString())
       renounceOwnershipTransferEvent.address = Address.fromString(selfSovereignNFT);
       handleOwnershipTransferred(renounceOwnershipTransferEvent)
 
-      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '1');
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "owner", ZERO_ADDRESS.toHexString());
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "deployer", deployer);
@@ -905,7 +903,6 @@ describe("KODA V4 Creator Contract tests", () => {
       ownershipTransferEvent.address = Address.fromString(selfSovereignNFT);
       handleOwnershipTransferred(ownershipTransferEvent)
 
-      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '3');
 
       let contractEntity = CreatorContract.load(selfSovereignNFT) as CreatorContract;
@@ -916,7 +913,6 @@ describe("KODA V4 Creator Contract tests", () => {
       renounceOwnershipTransferEvent.address = Address.fromString(selfSovereignNFT);
       handleOwnershipTransferred(renounceOwnershipTransferEvent)
 
-      assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'true');
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '2');
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "owner", DEAD_ADDRESS.toHexString());
       assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "deployer", deployer);

--- a/tests/mappings/v4/known-origin-v4-mapping-factory.test.ts
+++ b/tests/mappings/v4/known-origin-v4-mapping-factory.test.ts
@@ -75,7 +75,6 @@ describe("KODA V4 Factory tests", () => {
             assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "symbol", 'TEST')
             assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "filterRegistry", '0xf436269d6b7b9e8a76e6fb80c0a49681d4278747')
 
-            assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'false');
             assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '0');
 
             assert.entityCount(ACTIVITY_ENTITY_TYPE, 1);

--- a/tests/mappings/v4/known-origin-v4-mapping-factory.test.ts
+++ b/tests/mappings/v4/known-origin-v4-mapping-factory.test.ts
@@ -75,6 +75,9 @@ describe("KODA V4 Factory tests", () => {
             assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "symbol", 'TEST')
             assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "filterRegistry", '0xf436269d6b7b9e8a76e6fb80c0a49681d4278747')
 
+            assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "hasBeenTransferred", 'false');
+            assert.fieldEquals(CREATOR_CONTRACT_ENTITY_TYPE, selfSovereignNFT, "transferState", '0');
+
             assert.entityCount(ACTIVITY_ENTITY_TYPE, 1);
         })
 


### PR DESCRIPTION
Adding support for if a creator contracts ownership is transferred.

- [x] **originalOwner** - Which will store the address of the owner prior to burning/renouncing the contract
- [x] **transferState** - Tracks the state of the contracts transfers
0 - not transferred
1 - transferred to dead address with no artworks minted (FULL BURN)
2 - transferred to dead address with artworks minted (HALF BURN)
3 - transferred to another active address
- [x] **hasBeenTransferred** - Boolean, marks if the contract has been transferred or not

OriginalOwner attribute has not been added as the deployer/creator attribute already tracks this